### PR TITLE
Add the mCSD community as example

### DIFF
--- a/input/ch.fhir.ig.ch-epr-fhir.xml
+++ b/input/ch.fhir.ig.ch-epr-fhir.xml
@@ -236,6 +236,15 @@
         </resource>
         <resource>
             <reference>
+                <reference value="Organization/CommunityA"/>
+            </reference>
+            <name value="mCSD Organization Community A"/>
+            <description value="An example of CHmCSDOrganization that contains the same information as Community A in the Swiss examples
+(uid=CommunityA,OU=CHCommunity,DC=CPI,O=BAG,C=ch)"/>
+            <exampleCanonical value="http://fhir.ch/ig/ch-epr-fhir/StructureDefinition/CH.mCSD.Organization"/>
+        </resource>
+        <resource>
+            <reference>
                 <reference value="Organization/SpitalX"/>
             </reference>
             <name value="mCSD Organization Spital X"/>

--- a/input/fsh/identifier.fsh
+++ b/input/fsh/identifier.fsh
@@ -13,3 +13,13 @@ Invariant:   oid-start
 Description: "value must start with urn:oid:"
 Expression:  "value.startsWith('urn:oid:')"
 Severity:    #error
+
+Profile: LdapIdentifier
+Parent: Identifier
+Id: LdapIdentifier
+Title: "LDAP Identifier"
+Description: "Identifier with an LDAP DN"
+* ^url = "http://fhir.ch/ig/ch-epr-fhir/StructureDefinition/LdapIdentifier"
+* system 1..
+* system = "urn:ietf:rfc:4514" (exactly)
+* value 1..

--- a/input/fsh/mcsd_organization.fsh
+++ b/input/fsh/mcsd_organization.fsh
@@ -5,6 +5,14 @@ Title: "CH mCSD Organization"
 Description: "CH mCSD profile on Organization"
 * obeys ch-mcsd-organization-ihe-conformance
 * identifier 2.. // uid and hcIdentifier are required
+* identifier contains OID 0..1 and LDAP 0..1
+* identifier[OID] only OidIdentifier
+* identifier[OID] ^short = "The OID of the organization in the community"
+* identifier[OID] ^patternIdentifier.system = "urn:ietf:rfc:3986"
+* identifier[LDAP] only LdapIdentifier
+* identifier[LDAP] ^short = "LDAP DN (Distinguished Name), if the organization is stored in an HPD"
+* identifier[LDAP] ^patternIdentifier.system = "urn:ietf:rfc:4514"
+
 
 
 Invariant: ch-mcsd-organization-ihe-conformance
@@ -44,10 +52,10 @@ Title: "CH mCSD Organization Community A"
 Description: "An example of CHmCSDOrganization that contains the same information as Community A in the Swiss examples
 (uid=CommunityA,OU=CHCommunity,DC=CPI,O=BAG,C=ch)"
 * id = "CommunityA"
-* identifier[+].system = "urn:ietf:rfc:4514"
-* identifier[=].value = "uid=CommunityA,OU=CHCommunity,DC=CPI,O=BAG,C=ch"
-* identifier[+].system = "urn:ietf:rfc:3986"
-* identifier[=].value = "urn:oid:2.16.10.89"
+* identifier[LDAP].system = "urn:ietf:rfc:4514"
+* identifier[LDAP].value = "uid=CommunityA,OU=CHCommunity,DC=CPI,O=BAG,C=ch"
+* identifier[OID].system = "urn:ietf:rfc:3986"
+* identifier[OID].value = "urn:oid:2.16.10.89"
 * active = true
 * type[+].coding = http://terminology.hl7.org/CodeSystem/organization-type#cg "Community Group"
 * name = "Community A"
@@ -59,9 +67,10 @@ Title: "CH mCSD Organization Spital X"
 Description: "An example of CHmCSDOrganization that contains the same information as Spital X in the Swiss examples
 (uid=CommunityA:00000001000,OU=HCRegulatedOrganization,DC=HPD,O=BAG,C=ch)"
 * id = "SpitalX"
-* identifier[+].value = "uid=CommunityA:00000001000,OU=HCRegulatedOrganization,DC=HPD,O=BAG,C=ch"
-* identifier[+].system = "urn:ietf:rfc:3986"
-* identifier[=].value = "urn:oid:2.16.10.89.201"
+* identifier[LDAP].system = "urn:ietf:rfc:4514"
+* identifier[LDAP].value = "uid=CommunityA:00000001000,OU=HCRegulatedOrganization,DC=HPD,O=BAG,C=ch"
+* identifier[OID].system = "urn:ietf:rfc:3986"
+* identifier[OID].value = "urn:oid:2.16.10.89.201"
 * active = true
 * type[+].coding = $sct#394802001 "General medicine"
 * type[+].coding = $sct#22232009 "Hospital"
@@ -85,9 +94,10 @@ Title: "CH mCSD Organization Spital X Dept. 3"
 Description: "An example of CHmCSDOrganization that contains the same information as Spital X, Dept. 3 in the Swiss
 examples (uid=CommunityA:00000001004,OU=HCRegulatedOrganization,DC=HPD,O=BAG,C=ch)"
 * id = "SpitalXDept3"
-* identifier[+].value = "uid=CommunityA:00000001004,OU=HCRegulatedOrganization,DC=HPD,O=BAG,C=ch"
-* identifier[+].system = "urn:ietf:rfc:3986"
-* identifier[=].value = "urn:oid:2.16.10.89.203"
+* identifier[LDAP].system = "urn:ietf:rfc:4514"
+* identifier[LDAP].value = "uid=CommunityA:00000001004,OU=HCRegulatedOrganization,DC=HPD,O=BAG,C=ch"
+* identifier[OID].system = "urn:ietf:rfc:3986"
+* identifier[OID].value = "urn:oid:2.16.10.89.203"
 * active = true
 * type[+].coding = $sct#225728007 "Accident and Emergency department"
 * type[+].coding = $sct#22232009 "Hospital"
@@ -112,9 +122,10 @@ Title: "CH mCSD Organization Praxis P"
 Description: "An example of CHmCSDOrganization that contains the same information as Praxis P in the Swiss
 examples (uid=CommunityA:00000001001,OU=HCRegulatedOrganization,DC=HPD,O=BAG,C=ch)"
 * id = "PraxisP"
-* identifier[+].value = "uid=CommunityA:00000001001,OU=HCRegulatedOrganization,DC=HPD,O=BAG,C=ch"
-* identifier[+].system = "urn:ietf:rfc:3986"
-* identifier[=].value = "urn:oid:2.16.10.89.210"
+* identifier[LDAP].system = "urn:ietf:rfc:4514"
+* identifier[LDAP].value = "uid=CommunityA:00000001001,OU=HCRegulatedOrganization,DC=HPD,O=BAG,C=ch"
+* identifier[OID].system = "urn:ietf:rfc:3986"
+* identifier[OID].value = "urn:oid:2.16.10.89.210"
 * active = true
 * type[+].coding = $sct#35971002 "Ambulatory care site"
 * type[+].coding = $sct#394802001 "General medicine"

--- a/input/fsh/mcsd_organization.fsh
+++ b/input/fsh/mcsd_organization.fsh
@@ -4,7 +4,7 @@ Id: CH.mCSD.Organization
 Title: "CH mCSD Organization"
 Description: "CH mCSD profile on Organization"
 * obeys ch-mcsd-organization-ihe-conformance
-* identifier 2.. // uid and hcIdentifier are required
+* identifier 1..
 * identifier contains OID 0..1 and LDAP 0..1
 * identifier[OID] only OidIdentifier
 * identifier[OID] ^short = "The OID of the organization in the community"

--- a/input/fsh/mcsd_organization.fsh
+++ b/input/fsh/mcsd_organization.fsh
@@ -38,6 +38,21 @@ Title:    "LDAP schema"
 * contact.telecom -> "HCRegulatedOrganization.hpdMedicalRecordsDeliveryEmailAddress"
 
 
+Instance: ChmCSDOrganizationCommunityA
+InstanceOf: CHmCSDOrganization
+Title: "CH mCSD Organization Community A"
+Description: "An example of CHmCSDOrganization that contains the same information as Community A in the Swiss examples
+(uid=CommunityA,OU=CHCommunity,DC=CPI,O=BAG,C=ch)"
+* id = "CommunityA"
+* identifier[+].system = "urn:ietf:rfc:4514"
+* identifier[=].value = "uid=CommunityA,OU=CHCommunity,DC=CPI,O=BAG,C=ch"
+* identifier[+].system = "urn:ietf:rfc:3986"
+* identifier[=].value = "urn:oid:2.16.10.89"
+* active = true
+* type[+].coding = http://terminology.hl7.org/CodeSystem/organization-type#cg "Community Group"
+* name = "Community A"
+
+
 Instance: CHmCSDOrganizationSpitalX
 InstanceOf: CHmCSDOrganization
 Title: "CH mCSD Organization Spital X"

--- a/input/fsh/mcsd_practitioner.fsh
+++ b/input/fsh/mcsd_practitioner.fsh
@@ -5,6 +5,10 @@ Title: "CH mCSD Practitioner"
 Description: "CH mCSD profile on Practitioner"
 * obeys ch-mcsd-practitioner-ihe-conformance
 * qualification 1.. // hcProfession is required
+* identifier contains LDAP 0..1
+* identifier[LDAP] only LdapIdentifier
+* identifier[LDAP] ^short = "LDAP DN (Distinguished Name), if the practitioner is stored in an HPD"
+* identifier[LDAP] ^patternIdentifier.system = "urn:ietf:rfc:4514"
 
 
 Invariant: ch-mcsd-practitioner-ihe-conformance
@@ -50,9 +54,10 @@ Title: "CH mCSD Practitioner Dr. Peter Pan"
 Description: "An example of CHmCSDPractitioner that contains the same information as Dr. Peter Pan in the Swiss examples
 (uid=CommunityA:00000003002,OU=HCProfessional,DC=HPD,O=BAG,C=ch)"
 * id = "DrPeterPan"
-* identifier[+].system = "urn:oid:2.51.1.3"
-* identifier[=].value = "7601000102737"
-* identifier[+].value = "uid=CommunityA:00000003002,OU=HCProfessional,DC=HPD,O=BAG,C=ch"
+* identifier[GLN].system = "urn:oid:2.51.1.3"
+* identifier[GLN].value = "7601000102737"
+* identifier[LDAP].system = "urn:ietf:rfc:4514"
+* identifier[LDAP].value = "uid=CommunityA:00000003002,OU=HCProfessional,DC=HPD,O=BAG,C=ch"
 * active = true
 * name.text = "Peter Pan"
 * name.family = "Pan"

--- a/input/fsh/mcsd_practitionerrole.fsh
+++ b/input/fsh/mcsd_practitionerrole.fsh
@@ -9,6 +9,13 @@ Description: "CH mCSD profile on PractitionerRole"
 * organization only Reference(CHmCSDOrganization)
 * organization 1.. // From HPD
 * code 1.. // From mCSD
+* identifier ^slicing.discriminator.type = #pattern
+* identifier ^slicing.discriminator.path = "$this"
+* identifier ^slicing.rules = #open
+* identifier contains LDAP 0..1
+* identifier[LDAP] only LdapIdentifier
+* identifier[LDAP] ^short = "LDAP DN (Distinguished Name), if the relationship is stored in an HPD"
+* identifier[LDAP] ^patternIdentifier.system = "urn:ietf:rfc:4514"
 
 
 Invariant: ch-mcsd-practitionerrole-ihe-conformance
@@ -36,7 +43,8 @@ Title: "CH mCSD PractitionerRole Dr. Peter Pan at Spital X Dept. 3"
 Description: "An example of CHmCSDPractitionerRole that contains the same information as Dr. Peter Pan - Spital X, Dept. 3
 Relationship in the Swiss examples (CN=CommunityA:00000001004,OU=Relationship,DC=HPD,O=BAG,C=ch)"
 * id = "PeterPanSpitalXDept3"
-* identifier[+].value = "CN=CommunityA:00000001004,OU=Relationship,DC=HPD,O=BAG,C=ch"
+* identifier[LDAP].system = "urn:ietf:rfc:4514"
+* identifier[LDAP].value = "CN=CommunityA:00000001004,OU=Relationship,DC=HPD,O=BAG,C=ch"
 * active = true
 * practitioner = Reference(CHmCSDPractitionerDrPeterPan)
 * organization = Reference(CHmCSDOrganizationSpitalXDept3)
@@ -50,7 +58,8 @@ Title: "CH mCSD PractitionerRole Dr. Peter Pan at Praxis P"
 Description: "An example of CHmCSDPractitionerRole that contains the same information as Dr. Peter Pan - Praxis P
 Relationship in the Swiss examples (CN=CommunityA:00000001001,OU=Relationship,DC=HPD,O=BAG,C=ch)"
 * id = "PeterPanPraxisP"
-* identifier[+].value = "CN=CommunityA:00000001001,OU=Relationship,DC=HPD,O=BAG,C=ch"
+* identifier[LDAP].system = "urn:ietf:rfc:4514"
+* identifier[LDAP].value = "CN=CommunityA:00000001001,OU=Relationship,DC=HPD,O=BAG,C=ch"
 * active = true
 * practitioner = Reference(CHmCSDPractitionerDrPeterPan)
 * organization = Reference(CHmCSDOrganizationPraxisP)

--- a/input/pagecontent/Organization-CommunityA-intro.md
+++ b/input/pagecontent/Organization-CommunityA-intro.md
@@ -1,0 +1,2 @@
+**Note:** The Care Services Selective Supplier of an EPR community is not required to return the community itself as an
+Organization, this is optional.

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,4 +1,9 @@
+### Resolved Issues
+
+* mCSD: add the community as example [#200](https://github.com/ehealthsuisse/ch-epr-fhir/issues/200)
+
 ### DSTU4 Informative Ballot 2024 - Resolved Issues
+
 * Adapt IHE profiles for the Trace Context support [#153](https://github.com/ehealthsuisse/ch-epr-fhir/issues/153)
 * Remove XDS on FHIR option requirment for MHD [#193](https://github.com/ehealthsuisse/ch-epr-fhir/issues/193)
 * clarified the use of the redirect-uri as callback URL [#189](https://github.com/ehealthsuisse/ch-epr-fhir/issues/189)

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,5 +1,6 @@
 ### Resolved Issues
 
+* mCSD: set the system for LDAP DNs and add a slice to identifiers [#209](https://github.com/ehealthsuisse/ch-epr-fhir/issues/209)
 * mCSD: add the community as example [#200](https://github.com/ehealthsuisse/ch-epr-fhir/issues/200)
 
 ### DSTU4 Informative Ballot 2024 - Resolved Issues

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,5 +1,6 @@
 ### Resolved Issues
 
+* mCSD: require only one identifier for organizations [#210](https://github.com/ehealthsuisse/ch-epr-fhir/issues/210)
 * mCSD: set the system for LDAP DNs and add a slice to identifiers [#209](https://github.com/ehealthsuisse/ch-epr-fhir/issues/209)
 * mCSD: add the community as example [#200](https://github.com/ehealthsuisse/ch-epr-fhir/issues/200)
 


### PR DESCRIPTION
Issue: 
#200: add the CommunityA as an example of mCSD Organization
#209: add an LDAP slice to identifiers of the 3 resources
#210: lower the cardinality of Organization.identifier to 1..*

Preview: https://build.fhir.org/ig/ehealthsuisse/ch-epr-fhir/branches/200-mcsd-the-community-needs-to-be-an-organization/
QA: https://build.fhir.org/ig/ehealthsuisse/ch-epr-fhir/branches/200-mcsd-the-community-needs-to-be-an-organization/qa.html