### PR TITLE
#215 already fixed, but references extended authorization token

### DIFF
--- a/input/pagecontent/iti-104.md
+++ b/input/pagecontent/iti-104.md
@@ -120,7 +120,7 @@ The transaction SHALL be secured by Transport Layer Security (TLS) encryption an
 server certificates.
 
 The transaction SHALL use client authentication and authorization using basic authorization token as defined
-in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The extended authorization token SHALL be conveyed as
+in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The authorization token SHALL be conveyed as
 defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
 transaction.
 

--- a/input/pagecontent/iti-78.md
+++ b/input/pagecontent/iti-78.md
@@ -89,7 +89,7 @@ The transaction SHALL be secured by Transport Layer Security (TLS) encryption an
 server certificates.
 
 The transaction SHALL use client authentication and authorization using basic authorization token as defined
-in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The extended authorization token SHALL be conveyed as
+in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The authorization token SHALL be conveyed as
 defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
 transaction.
 

--- a/input/pagecontent/iti-83.md
+++ b/input/pagecontent/iti-83.md
@@ -110,8 +110,8 @@ The CapabilityStatement resource for the **Patient Identifier Cross-reference Ma
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
 server certificates.
 
-The transaction SHALL use client authentication and authorization using basic authorization token as defined
-in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The extended authorization token SHALL be conveyed as
+The transaction SHALL use client authentication and authorization using authorization token as defined
+in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The authorization token SHALL be conveyed as
 defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
 transaction.
 

--- a/input/pagecontent/iti-83.md
+++ b/input/pagecontent/iti-83.md
@@ -110,7 +110,7 @@ The CapabilityStatement resource for the **Patient Identifier Cross-reference Ma
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
 server certificates.
 
-The transaction SHALL use client authentication and authorization using authorization token as defined
+The transaction SHALL use client authentication and authorization using basic authorization token as defined
 in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The authorization token SHALL be conveyed as
 defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
 transaction.


### PR DESCRIPTION
removed for the three transactions "refeference" that it only says

The authorization token SHALL be conveyed as