### PR TITLE
Make the traceparent value optional in audit events + other small fixes

### DIFF
--- a/input/fsh/auditevents.fsh
+++ b/input/fsh/auditevents.fsh
@@ -48,7 +48,7 @@ RuleSet: ChAuditEventRules
 * source
   * site 1..1
   * site ^short = "The OID of the audit source"
-* entity contains traceparent 1..1
+* entity contains traceparent 0..1
 * entity[traceparent]
   * ^short = "The 'traceparent' header value of the transaction"
   * what 1..1

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -12,6 +12,15 @@ Reference to retired ValueSet http://terminology.hl7.org/ValueSet/v3-ActUSPrivac
 A definition for CodeSystem 'urn:ihe:event-type-code' could not be found, so the code cannot be validated
 A definition for CodeSystem 'urn:e-health-suisse:event-type-code' could not be found, so the code cannot be validated
 
+# Inactive codes used in value sets
+The code '264358009' is valid but is not active
+
+# Non-conformance to 'preferred' value sets
+None of the codings provided are in the value set 'Practice Setting Code Value Set' (http://hl7.org/fhir/ValueSet/c80-practice-codes|4.0.1), and a coding is recommended to come from this value set (codes = urn:oid:2.16.756.5.30.1.127.3.5#1051)
+
 # IHE things
 For the complex type Coding, consider using a pattern rather than a fixed value to avoid over-constraining the instance
 The definition for the element 'Consent.provision.code' binds to the value set 'http://hl7.org/fhir/ValueSet/consent-content-code' which is experimental, but this structure is not labeled as experimental
+
+# IG Publisher limitations
+No types could be determined from the search string, so the types can't be checked

--- a/input/images-source/MHD_actor_diagram.plantuml
+++ b/input/images-source/MHD_actor_diagram.plantuml
@@ -5,6 +5,6 @@ agent "Document Source" as DocumentSource
 agent "Document Consumer" as DocumentConsumer
 agent "Document Responder" as DocumentResponder
 agent "Document Recipient" as DocumentRecipient
-DocumentConsumer --> DocumentResponder : "[[ITI-67.html ITI-67 Find Document References]]\n[[iti-68.html ITI-68 Retrieve Document]]"
+DocumentConsumer --> DocumentResponder : "[[iti-67.html ITI-67 Find Document References]]\n[[iti-68.html ITI-68 Retrieve Document]]"
 DocumentSource --> DocumentRecipient : "[[iti-65.html ITI-65 Provide Document Bundle]]\n[[ch-mhd-1.html CH:MHD-1 Update Document Metadata]]"
 @enduml

--- a/input/images-source/overview.plantuml
+++ b/input/images-source/overview.plantuml
@@ -44,7 +44,7 @@ component "EPR API" {
   MHDSource --> MHDRecipient : Provide Document Bundle [ITI-65], \nUpdate Document Metadata [CH:MHD-1]
 
   [MHD Document Responder] as MHDResponder
-  MHDConsumer --> MHDResponder : nFind Document References [ITI-67], \nRetrieve Document [ITI-68] 
+  MHDConsumer --> MHDResponder : Find Document References [ITI-67], \nRetrieve Document [ITI-68]
 
   [RESTful ATNA Audit Record Repository] as ATNARepository
   ATNANode --> ATNARepository : Record Audit Event [ITI-20]

--- a/input/resources/structuredefinition/ch-epr-fhir-birthname.xml
+++ b/input/resources/structuredefinition/ch-epr-fhir-birthname.xml
@@ -49,7 +49,7 @@
                 <rules value="closed" />
             </slicing>
             <min value="1"/>
-            <max value="1" />
+            <max value="2" />
         </element>
         <element id="HumanName.family.extension:iso21090-EN-qualifier">
             <path value="HumanName.family.extension" />


### PR DESCRIPTION
The specifications don't require alThe specifications don't require all actors to send the traceparent value, so it should be optional everywhere.l actors to send the traceparent value, so it should be optional everywhere.

It also contains other typo/QA fixes.