### PR TITLE
allow usage of Consent.sourceAttachment; fix policy documentation URL

### DIFF
--- a/input/fsh/ppqm_consent.fsh
+++ b/input/fsh/ppqm_consent.fsh
@@ -70,7 +70,10 @@ Description: "Swiss EPR Policy Set as a Consent"
 
 * organization  0..0
 
-* source[x]     0..0
+* sourceReference               0..0
+* sourceAttachment              0..1
+* sourceAttachment.contentType  1..1
+* sourceAttachment.contentType  = urn:ietf:bcp:13#application/xacml+xml
 
 * policy        0..0
 
@@ -187,7 +190,7 @@ Profile: PpqmConsentTemplate202
 Parent: PpqmConsent
 Id: PpqmConsentTemplate202
 Title: "EPR policy set based on template 202"
-Description: "EPR policy set based on template 202 -- grants healthcare professionals access to the patient's EPR in emergency mode.  This policy set shall be created during the patient's onboarding, but can be modified later."
+Description: "EPR policy set based on template 202 -- grants healthcare professionals access to the patient's EPR in emergency mode.  This policy set can be created during the patient's onboarding or later, and can be modified."
 * identifier[templateId].value = "202"
 * policyRule.coding from PpqmReferencedPolicySetGroupEmergency (required)
 * provision.period 0..0
@@ -201,7 +204,7 @@ Description: "EPR policy set based on template 202 -- grants healthcare professi
 Instance: PpqmConsentTemplate202Example
 InstanceOf: PpqmConsentTemplate202
 Title: "EPR policy set based on template 202"
-Description: "EPR policy set based on template 202 -- grants healthcare professionals access to the patient's EPR in emergency mode.  This policy set shall be created during the patient's onboarding, but can be modified later."
+Description: "EPR policy set based on template 202 -- grants healthcare professionals access to the patient's EPR in emergency mode.  This policy set can be created during the patient's onboarding or later, and can be modified."
 Usage: #example
 * text.status = #empty
 * text.div = "<div xmlns='http://www.w3.org/1999/xhtml'><p>Template 202 - Read access in emergency mode</p></div>"
@@ -278,7 +281,9 @@ Usage: #example
 * provision.actor.reference.identifier.type.coding = $URI#urn:gs1:gln
 * provision.actor.reference.identifier.value = "7600000000005"
 * provision.actor.reference.identifier.system = "urn:oid:2.51.1.3"
-
+* sourceAttachment.contentType = urn:ietf:bcp:13#application/xacml+xml
+* sourceAttachment.data = "PFBvbGljeVNldA0KCXhtbG5zOnhzaT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS9YTUxTY2hlbWEtaW5zdGFuY2UiDQoJeG1sbnM6aGw3PSJ1cm46aGw3LW9yZzp2MyINCgl4bWxucz0idXJuOm9hc2lzOm5hbWVzOnRjOnhhY21sOjIuMDpwb2xpY3k6c2NoZW1hOm9zIg0KCVBvbGljeVNldElkPSJ1cm46dXVpZDplNjkzNjU3Yy01MGJlLTQ2YTYtYmRjZC0wNTI2OTE0N2YzMDQiDQoJUG9saWN5Q29tYmluaW5nQWxnSWQ9InVybjpvYXNpczpuYW1lczp0Yzp4YWNtbDoxLjA6cG9saWN5LWNvbWJpbmluZy1hbGdvcml0aG06ZGVueS1vdmVycmlkZXMiPiANCg0KLi4uDQo="
+* sourceAttachment.title = "Let this doctor access my restricted documents"
 
 Profile: PpqmConsentTemplate302
 Parent: PpqmConsent

--- a/input/pagecontent/ppqm.md
+++ b/input/pagecontent/ppqm.md
@@ -137,19 +137,18 @@ See also:
 - CH:PPQ specification in the [Amendment 2.1 of Annex 5 EPRO-FDHA](https://www.fedlex.admin.ch/eli/oc/2023/221/de/annexes).
 - [Policy set templates](https://github.com/ehealthsuisse/ch-epr-adr-ppq/tree/main/Privacy%20Policy%20Stack/Patient%20Specific%20via%20Policy%20Manager)
   in the official EPR policy stack.
-- [Description of the official EPR policy stack](https://github.com/ehealthsuisse/ch-epr-adr-ppq/blob/main/docs/Policies.md).
+- [Description of the official EPR policy stack](https://github.com/ehealthsuisse/ch-epr-adr-ppq/tree/HEAD/docs/Policies.md).
 
 ### Relation between CH:PPQm and CH:PPQ
 
 _This section is not normative._
 
-Implementers may decide to implement CH:PPQm transactions on top of CH:PPQ ones, i.e. to create a FHIR layer over an 
-existing XACML-based Policy Repository. The CH:PPQm specification supports this approach by defining transactions 
-and data structures in a way which allows an efficient bridging between CH:PPQ and CH:PPQm, and by providing message 
-transformation rules (see the page [Mappings](StructureDefinition-PpqmConsent-mappings.html)).
-
-In terms of actor grouping, this would mean that the Policy Repository may be optionally grouped with CH:PPQ Policy 
-Source and CH:PPQ Policy Consumer in order to communicate over PPQ-1 and PPQ-2 with itself.
+The CH:PPQm specification defines transactions and data structures in a way which allows an efficient 
+bridging between CH:PPQ and CH:PPQm, and by providing message transformation rules 
+(see the page [Mappings](StructureDefinition-PpqmConsent-mappings.html)).  This allows to implement 
+CH:PPQm transactions on top of CH:PPQ ones (i.e. to create a FHIR layer over an existing XACML-based 
+Policy Repository), or vice versa.  In the latter case, original XACML contents may be stored in the 
+attribute `sourceAttachment` of a FHIR Consent. 
 
 Note that CH:PPQm is not intended to handle base policies and policy sets, i.e. the ones provided in the official 
 Policy Stack and not related to any particular patients.


### PR DESCRIPTION
For using FHIR as a technical basis of a Policy Repository, it may be advantageous to store original XACML policy sets directly in FHIR Consent resources -- for that, the attribute Consent.sourceAttachment shall be enabled.  Another minor change is the URL or policy documentation, which now references the default branch whichever it is.