### PR TITLE
Fix the AuditEvent action for the CH:MHD-1 transaction

### DIFF
--- a/input/fsh/mhd_auditevent.fsh
+++ b/input/fsh/mhd_auditevent.fsh
@@ -203,7 +203,7 @@ Description: "This profile is used to define the CH Audit Event for the [CH:MHD-
 Source'."
 * modifierExtension 0..0
 * type = DCM#110106 "Export"
-* action = #R
+* action = #U
 * subtype ^slicing.discriminator.type = #value
 * subtype ^slicing.discriminator.path = "$this"
 * subtype ^slicing.rules = #open // allow other codes
@@ -263,7 +263,7 @@ Description: "This profile is used to define the CH Audit Event for the [CH:MHD-
 Recipient'."
 * modifierExtension 0..0
 * type = DCM#110107 "Import"
-* action = #C
+* action = #U
 * subtype ^slicing.discriminator.type = #value
 * subtype ^slicing.discriminator.path = "$this"
 * subtype ^slicing.rules = #open // allow other codes

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -9,6 +9,7 @@
 
 * add SCT edition in the expansion parameters [#256](https://github.com/ehealthsuisse/ch-epr-fhir/issues/256)
 * Wrong optionality of the attribute Consent.provision.period [#255](https://github.com/ehealthsuisse/ch-epr-fhir/issues/255)
+* Wrong AuditEvent action for the CH:MHD-1 transaction [#270](https://github.com/ehealthsuisse/ch-epr-fhir/issues/270)
 
 
 


### PR DESCRIPTION
Fixes #270

Preview: https://build.fhir.org/ig/ehealthsuisse/ch-epr-fhir/branches/270-chmhd-1-audit-event-profile-for-document-recipient-action-element-fixed-to-c/