### PR TITLE
Remove `DocumentReference.date` from the MHD profile #274

### DIFF
--- a/input/examples/documentreference/2-7-DocRefMedicationCard.json
+++ b/input/examples/documentreference/2-7-DocRefMedicationCard.json
@@ -73,7 +73,6 @@
     "subject": {
         "reference": "http://example.org/Patient/FranzMusterNeedsAbsoluteUrl"
     },
-    "date": "2020-06-29T11:58:00.000+00:00",
     "description": "2-7-MedicationCard",
     "securityLabel": [
         {

--- a/input/fsh/mhd.fsh
+++ b/input/fsh/mhd.fsh
@@ -87,7 +87,6 @@ Description: "CH MHD Profile on CH Core DocumentReference"
 * subject only Reference($ch-core-patient)
 * subject ^comment = "Not a contained resource. URL Points to an existing Patient Resource representing the XDS Affinity Domain Patient."
 * subject ^type.aggregation = #referenced
-* date 1.. MS
 * author only Reference
 * author MS
 * author ^comment = "Contained resource."

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -4,6 +4,7 @@
 
 * Unknown code '26' in the CodeSystem 'http://terminology.hl7.org/CodeSystem/object-role' version '1.0.0': waiting to be added, see [#190](https://github.com/ehealthsuisse/ch-epr-fhir/issues/190)
 * in review: ITI-71: Conflict between OAuth2 scope and ITI-71 scope [#245](https://github.com/ehealthsuisse/ch-epr-fhir/issues/245)  
+* Remove `DocumentReference.date` from the MHD profile [#274](https://github.com/ehealthsuisse/ch-epr-fhir/issues/274)
 
 #### Resolved Issues
 


### PR DESCRIPTION
As discussed in #274.
Preview: https://build.fhir.org/ig/ehealthsuisse/ch-epr-fhir/branches/274-documentreference-invalid-mapping-of-documententrycreationtime/StructureDefinition-ch-mhd-documentreference-comprehensive.html