### PR TITLE
#255 ch atc integration

### DIFF
--- a/input/pagecontent/ch-atc.md
+++ b/input/pagecontent/ch-atc.md
@@ -178,24 +178,4 @@ This profile supports the following Use Cases:
 </ol>
 
 ### Security Considerations
-
-The transaction is used to exchange sensitive information and requires authentication and authorization.
-This profile allows two authentication mechanisms; The Patient Audit Record Repository shall support both options,
-the Patient Audit Consumer shall select one option.
-
-Access control shall be implemented by grouping the CH:ATC Audit Consumer and Audit Record Repository with the Authorization Client and Resource Server from the IUA trial implementation profile using either the SAML Token option or the JWT Token option. As defined therein, the CH:ATC Audit Consumer and Audit Record Repository shall implement the Incorporate Authorization Token [ITI-72] transaction to convey the token.
-
-#### IUA with SAML Token Option
-
-With [IUA with SAML Token Option](https://profiles.ihe.net/ITI/IUA/index.html#372432-saml-token-option) the actors SHALL be grouped with 
-Secure Node or Secure Application implementing the "STX: TLS 1.2 floor using 
-BCP195 Option" defined in the [IHE ITI TF-2, chapter 3.19.6.2.3](https://profiles.ihe.net/ITI/TF/Volume2/ITI-19.html#3.19.6.2.3);
-the token incorporated with ITI-72 is a XUA token, as described in the Amendment 1 of Annex 5 EPRO-FDHA.
-
-#### IUA with JWT Token Option
-
-With [IUA with JWT Token Option](https://profiles.ihe.net/ITI/IUA/index.html#372432-saml-token-option) 
-the token incorporated with ITI-72 is an [Extended Access Token](iti-71.html#json-web-token-option); the
-transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with server certificates.
-
-The CH:ATC Patient Audit Record Repository shall be grouped with CH:ADR, i.e. the CH:ATC Patient Audit Record Repository shall use the CH:ADR Authorization Decision Request transaction to authorize the transaction and enforce the authorization decision retrieved from CH:ADR Authorization Decision Response.
+This national extension enforces authentication and authorization of access using the IUA profile with basic access token as described in [IUA](iti-71.html).

--- a/input/pagecontent/ch-atc.md
+++ b/input/pagecontent/ch-atc.md
@@ -183,19 +183,19 @@ The transaction is used to exchange sensitive information and requires authentic
 This profile allows two authentication mechanisms; The Patient Audit Record Repository shall support both options,
 the Patient Audit Consumer shall select one option.
 
-<ol>
-<li>
-  Option 1: both actors are grouped with Secure Node or Secure Application implementing the "STX: TLS 1.2 floor using 
-  BCP195 Option" defined in the [IHE ITI TF-2, chapter 3.19.6.2.3](https://profiles.ihe.net/ITI/TF/Volume2/ITI-19.html#3.19.6.2.3);
-  the token incorporated with ITI-72 is a XUA token, as described in the Amendment 1 of Annex 5 EPRO-FDHA.
-</li>
-<li>
-  Option 2: the token incorporated with ITI-72 is an [Extended Access Token](Get Access Token [ITI-71]); the
-  transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with server 
-  certificates.
-</li>
-</ol>
+Access control shall be implemented by grouping the CH:ATC Audit Consumer and Audit Record Repository with the Authorization Client and Resource Server from the IUA trial implementation profile using either the SAML Token option or the JWT Token option. As defined therein, the CH:ATC Audit Consumer and Audit Record Repository shall implement the Incorporate Authorization Token [ITI-72] transaction to convey the token.
 
-Access control shall be implemented by grouping the CH:ATC Audit Consumer and Audit Record Repository with the Authorization Client and Resource Server from the IUA trial implementation profile using the SAML Token option (see [IHE ITI Supplement IUA, chapter 3.72.4.3.2](https://profiles.ihe.net/ITI/IUA/index.html#372432-saml-token-option)). As defined therein, the CH:ATC Audit Consumer and Audit Record Repository shall implement the Incorporate Authorization Token [ITI-72] transaction to convey the XUA token.
+#### IUA with SAML Token Option
+
+With [IUA with SAML Token Option](https://profiles.ihe.net/ITI/IUA/index.html#372432-saml-token-option) the actors SHALL be grouped with 
+Secure Node or Secure Application implementing the "STX: TLS 1.2 floor using 
+BCP195 Option" defined in the [IHE ITI TF-2, chapter 3.19.6.2.3](https://profiles.ihe.net/ITI/TF/Volume2/ITI-19.html#3.19.6.2.3);
+the token incorporated with ITI-72 is a XUA token, as described in the Amendment 1 of Annex 5 EPRO-FDHA.
+
+#### IUA with JWT Token Option
+
+With [IUA with JWT Token Option](https://profiles.ihe.net/ITI/IUA/index.html#372432-saml-token-option) 
+the token incorporated with ITI-72 is an [Extended Access Token](iti-71.html#json-web-token-option); the
+transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with server certificates.
 
 The CH:ATC Patient Audit Record Repository shall be grouped with CH:ADR, i.e. the CH:ATC Patient Audit Record Repository shall use the CH:ADR Authorization Decision Request transaction to authorize the transaction and enforce the authorization decision retrieved from CH:ADR Authorization Decision Response.

--- a/input/pagecontent/ch-atc.md
+++ b/input/pagecontent/ch-atc.md
@@ -178,4 +178,4 @@ This profile supports the following Use Cases:
 </ol>
 
 ### Security Considerations
-This national extension enforces authentication and authorization of access using the IUA profile with basic access token as described in [IUA](iti-71.html).
+This national extension enforces authentication and authorization of access using the IUA profile as described in [IUA](iti-71.html).

--- a/input/pagecontent/ch-mhd-1.md
+++ b/input/pagecontent/ch-mhd-1.md
@@ -206,10 +206,9 @@ See http://hl7.org/fhir/http.html#update for response.
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
 server certificates. Transactions across communities SHALL use mTLS.
 
-The transaction SHALL use client authentication and authorization using extended authorization token as defined
-in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The extended authorization token SHALL be conveyed as
-defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
-transaction.
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
 All Document Recipients except the one with the Federated Cross Community Access Option SHALL be grouped with the Authorization Decision Consumer actor of the CH:ADR profile
 defined in Extension 2.1 to Annex 5 of the ordinances and perform an Authorization Decision Request [CH:ADR] for

--- a/input/pagecontent/iti-104.md
+++ b/input/pagecontent/iti-104.md
@@ -119,7 +119,7 @@ The CapabilityStatement resource for the **Patient Identifier Cross-reference Ma
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
 server certificates.
 
-The transaction SHALL use client authentication and authorization using basic authorization token as defined
+The transaction SHALL use client authentication and authorization using basic access token as defined
 in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The authorization token SHALL be conveyed as
 defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
 transaction.

--- a/input/pagecontent/iti-104.md
+++ b/input/pagecontent/iti-104.md
@@ -119,10 +119,9 @@ The CapabilityStatement resource for the **Patient Identifier Cross-reference Ma
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
 server certificates.
 
-The transaction SHALL use client authentication and authorization using basic access token as defined
-in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The authorization token SHALL be conveyed as
-defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
-transaction.
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use a basic access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer.
 
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
 

--- a/input/pagecontent/iti-119.md
+++ b/input/pagecontent/iti-119.md
@@ -121,10 +121,9 @@ The CapabilityStatement resource for the **Patient Demographics Supplier** is
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
 server certificates.
 
-The transaction SHALL use client authentication and authorization using basic access token as defined
-in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The authorization token SHALL be conveyed as
-defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
-transaction.
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use a basic access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer.
 
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
 

--- a/input/pagecontent/iti-119.md
+++ b/input/pagecontent/iti-119.md
@@ -121,7 +121,7 @@ The CapabilityStatement resource for the **Patient Demographics Supplier** is
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
 server certificates.
 
-The transaction SHALL use client authentication and authorization using basic authorization token as defined
+The transaction SHALL use client authentication and authorization using basic access token as defined
 in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The authorization token SHALL be conveyed as
 defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
 transaction.

--- a/input/pagecontent/iti-20.md
+++ b/input/pagecontent/iti-20.md
@@ -57,6 +57,11 @@ The CapabilityStatement resource for the **Audit Record Repository** is
 
 ### Security Consideration
 
-TLS SHALL be used.
+The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
+server certificates.
+
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use a basic access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer.
 
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).

--- a/input/pagecontent/iti-65.md
+++ b/input/pagecontent/iti-65.md
@@ -80,10 +80,9 @@ The CapabilityStatement resource for the **Document Recipient** is [MHD Document
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with 
 server certificates. 
 
-The transaction SHALL use client authentication and authorization using extended authorization token as defined 
-in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The extended authorization token SHALL be conveyed as 
-defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) 
-transaction.
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
 The Document Recipient actor SHALL be grouped with the Authorization Decision Consumer actor of the CH:ADR profile
 defined in Extension 2.1 to Annex 5 of the ordinances and perform an Authorization Decision Request [CH:ADR] for 

--- a/input/pagecontent/iti-67.md
+++ b/input/pagecontent/iti-67.md
@@ -79,10 +79,9 @@ The CapabilityStatement resource for the **Document Responder** is [MHD Document
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
 server certificates. Transactions across communities SHALL use mTLS.
 
-The transaction SHALL use client authentication and authorization using extended authorization token as defined
-in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The extended authorization token SHALL be conveyed as
-defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
-transaction.
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
 All Document Responders except the one with the Federated Cross Community Access Option SHALL be grouped with the Authorization Decision Consumer actor of the CH:ADR profile
 defined in Extension 2.1 to Annex 5 of the ordinances and perform an Authorization Decision Request [CH:ADR] for

--- a/input/pagecontent/iti-68.md
+++ b/input/pagecontent/iti-68.md
@@ -46,7 +46,7 @@ The transaction SHALL use client authentication and authorization using one of t
 1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
-3. All Document Responders except the one with the Federated Cross Community Access Option SHALL be grouped with the Authorization Decision Consumer actor of the CH:ADR profile
+All Document Responders except the one with the Federated Cross Community Access Option SHALL be grouped with the Authorization Decision Consumer actor of the CH:ADR profile
 defined in Extension 2.1 to Annex 5 of the ordinances and perform an Authorization Decision Request [CH:ADR] for
 every Retrieve Document [ITI-68] request.
 

--- a/input/pagecontent/iti-68.md
+++ b/input/pagecontent/iti-68.md
@@ -42,12 +42,11 @@ The CapabilityStatement resource for the **Document Responder** is [MHD Document
 
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with server certificates. Transactions across communities SHALL use mTLS.
 
-The transaction SHALL use client authentication and authorization using extended authorization token as defined
-in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The extended authorization token SHALL be conveyed as
-defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
-transaction.
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
-All Document Responders except the one with the Federated Cross Community Access Option SHALL be grouped with the Authorization Decision Consumer actor of the CH:ADR profile
+3. All Document Responders except the one with the Federated Cross Community Access Option SHALL be grouped with the Authorization Decision Consumer actor of the CH:ADR profile
 defined in Extension 2.1 to Annex 5 of the ordinances and perform an Authorization Decision Request [CH:ADR] for
 every Retrieve Document [ITI-68] request.
 

--- a/input/pagecontent/iti-81.md
+++ b/input/pagecontent/iti-81.md
@@ -45,34 +45,16 @@ The returned AuditEvent FHIR resources in the Bundle shall conform the CH:ATC Au
 
 #### Security Considerations
 
-The transaction is used to exchange sensitive information and requires authentication and authorization.
-This profile allows two authentication mechanisms; The Patient Audit Record Repository shall support both options,
-the Patient Audit Consumer shall select one option.
+The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
+server certificates.
 
-<ol>
-<li>
-  Option 1: both actors are grouped with Secure Node or Secure Application implementing the "STX: TLS 1.2 floor using 
-  BCP195 Option" defined in the [IHE ITI TF-2, chapter 3.19.6.2.3](https://profiles.ihe.net/ITI/TF/Volume2/ITI-19.html#3.19.6.2.3);
-  the token incorporated with ITI-72 is a XUA token, as described in the Amendment 1 of Annex 5 EPRO-FDHA.
-</li>
-<li>
-  Option 2: the token incorporated with ITI-72 is an [Extended Access Token](Get Access Token [ITI-71]); the
-  transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with server 
-  certificates.
-</li>
-</ol>
-
-Access control shall be implemented by grouping the CH:ATC Audit Consumer and Audit Record Repository with the Authorization Client and Resource Server from the IUA trial implementation profile using the SAML Token option (see [IHE ITI Supplement IUA , chapter 3.72.4.3.2](https://profiles.ihe.net/ITI/IUA/index.html#372432-saml-token-option)). As defined therein, the CH:ATC Audit Consumer and Audit Record Repository shall implement the Incorporate Authorization Token [ITI-72] transaction to convey the XUA token.
-
-The actors shall implement the Incorporate Authorization Token [ITI-72] transaction with SAML token option, using the base64url encoded SAML assertion defined in XUA to the authorization header of the HTTP1.1 GET request with key "Bearer" as follows:
-``` http
-GET /example/url/to/resource/location HTTP/1.1
-Authorization: Bearer fFBGRNJru1FQd[…omitted for brevity…]44AzqT3Zg
-Host: examplehost.com
-```
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
 The CH:ATC Patient Audit Record Repository shall be grouped with CH:ADR, i.e. the CH:ATC Patient Audit Record Repository shall use the CH:ADR Authorization Decision Request transaction to authorize the transaction and enforce the authorization decision retrieved from CH:ADR Authorization Decision Response.
 
+The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
 
 #### Security Audit Considerations
 An audit event as specified in [Access Audit Trail Content Profile](volume-3.html#access-audit-trail-content-profile) shall be returned by a query to Patient Audit Record Repository after the Patient Audit Record Repository has been queried by a Patient Audit Consumer.

--- a/input/pagecontent/iti-83.md
+++ b/input/pagecontent/iti-83.md
@@ -111,10 +111,9 @@ The CapabilityStatement resource for the **Patient Identifier Cross-reference Ma
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
 server certificates.
 
-The transaction SHALL use client authentication and authorization using basic access token as defined
-in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The authorization token SHALL be conveyed as
-defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
-transaction.
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use a basic access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer.
 
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
 

--- a/input/pagecontent/iti-83.md
+++ b/input/pagecontent/iti-83.md
@@ -111,7 +111,7 @@ The CapabilityStatement resource for the **Patient Identifier Cross-reference Ma
 The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
 server certificates.
 
-The transaction SHALL use client authentication and authorization using basic authorization token as defined
+The transaction SHALL use client authentication and authorization using basic access token as defined
 in the [IUA profile](https://profiles.ihe.net/ITI/IUA). The authorization token SHALL be conveyed as
 defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72)
 transaction.

--- a/input/pagecontent/iti-90.md
+++ b/input/pagecontent/iti-90.md
@@ -158,9 +158,12 @@ The CapabilityStatement resource for the **Directory** is
 
 ### Security Considerations
 
-TLS SHALL be used. This national extension enforces authentication and authorization of access to the _Directory_ using 
-the IUA profile with basic access token. Consequently, the _Find Matching Care Services_
-[ITI-90] request must authorize using the [[ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction of the IUA profile.
+The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
+server certificates.
+
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use a basic access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer.
 
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
 

--- a/input/pagecontent/iti-iua.md
+++ b/input/pagecontent/iti-iua.md
@@ -87,8 +87,8 @@ The healthcare professional reports medical information of a treatment in her pr
 a structured or unstructured document from the data and stores them in the clinical archive system. The clinical archive
 system decides whether the document shall be stored in the patients EHR using the policies defined in the clinic.
 
-To access the patient EHR the clinical archive system first request a basic authorization token using the client
-credential flow and uses the basic authorization token in the PIXm or PDQm transactions used to retrieve the EHR-SPID
+To access the patient EHR the clinical archive system first request a basic access token using the client
+credential flow and uses the basic access token in the PIXm or PDQm transactions used to retrieve the EHR-SPID
 and the XAD PID of the patient.
 
 The Authorization server returns the basic access token if the clinical archive systems is registered beforehand and is

--- a/input/pagecontent/iti-iua.md
+++ b/input/pagecontent/iti-iua.md
@@ -117,9 +117,7 @@ The IUA Trial Implementation supports three options for the Authorization Token 
 and the Token Introspection option. Since this national extension will apply to cross community communication, the Token
 Introspection Option SHALL NOT be used.
 
-This national extension intends to simplify and modernize the technologies used to connect to the Swiss EPR. The legacy
-SAML Token option SHALL NOT be used. To support automated client configuration the Authorization Server actor SHALL
-support the Authorization Metadata option.
+To support automated client configuration the Authorization Server actor SHALL support the Authorization Metadata option.
 
 ### Grouping
 

--- a/input/pagecontent/iti-iua.md
+++ b/input/pagecontent/iti-iua.md
@@ -132,7 +132,7 @@ see [sequence diagrams](sequencediagrams.html).
 ### Security Consideration
 
 Portals and primary systems SHALL be identified by the client_id and client_secret registered during onboarding. All
-requests to the IUA Authorization Server SHALL be authenticated by the digital signatures.
+requests to the IUA Authorization Server SHALL be authenticated by the digital signatures of the messages.
 
 Implementers SHALL register the combination of the OAuth client ID, the URLs and the certificate used for message
 signatures during the onboarding process and keep the data up to date.

--- a/input/pagecontent/iti-mcsd.md
+++ b/input/pagecontent/iti-mcsd.md
@@ -49,8 +49,8 @@ Therefore, actors of this profile must be grouped with actors of other profiles 
 
 ### Security Consideration
 
-This national extension enforces authentication and authorization of access to the _Directory_
-using the IUA profile with basic access token as described in [IUA](iti-71.html).
+This national extension enforces authentication and authorization of access to the _Care Services Selective Supplier_
+using the IUA profile as described in [IUA](iti-71.html).
 
 ### Examples
 

--- a/input/pagecontent/iti-mhd.md
+++ b/input/pagecontent/iti-mhd.md
@@ -94,4 +94,5 @@ This national extension enforces authentication and authorization for access con
 For the process flow of this profile and its interplay with the other profiles see [sequence diagrams](sequencediagrams.html). 
 
 ### Security Consideration
-This national extension enforces authentication and authorization of access to the Patient Identity Manager using the IUA profile with extended access token as described in [IUA](iti-71.html#expected-actions-1).
+This national extension enforces authentication and authorization of access to the Patient Identity Manager using the 
+IUA profile as described in [IUA](iti-71.html#expected-actions-1).

--- a/input/pagecontent/iti-pdqm.md
+++ b/input/pagecontent/iti-pdqm.md
@@ -33,4 +33,5 @@ This national extension enforces authentication and authorization for access con
 <figcaption ID="1">Table 1: Grouping of PDQm actors required by this national extension. </figcaption>
 
 ###	Security Consideration
-This national extension enforces authentication and authorization of access to the Patient Demographics Supplier using the IUA profile with basic access token as described in [IUA](iti-71.html).
+This national extension enforces authentication and authorization of access to the Patient Demographics Supplier using 
+the IUA profile as described in [IUA](iti-71.html).

--- a/input/pagecontent/iti-pixm.md
+++ b/input/pagecontent/iti-pixm.md
@@ -36,4 +36,5 @@ This national extension enforces authentication and authorization for access con
 For the process flow of this profile and its interplay with the other profiles see [sequence diagrams](sequencediagrams.html). 
 
 ###	Security Consideration
-This national extension enforces authentication and authorization of access to the Patient Identifier Cross-reference Manager using the IUA profile with basic access token as described in [IUA](iti-71.html).
+This national extension enforces authentication and authorization of access to the Patient Identifier Cross-reference 
+Manager using the IUA profile as described in [IUA](iti-71.html).

--- a/input/pagecontent/iti-restful-atna.md
+++ b/input/pagecontent/iti-restful-atna.md
@@ -23,4 +23,5 @@ The Audit Record Repository SHALL support the ATX: FHIR Feed Option.
 The Swiss national extension does not define requirements on the grouping of actors in this profile, which extend or restrict the grouping required from the ATNA profile.
 
 ### Security Consideration
-The Swiss national extension does not define additional requirements on ATNA Security Considerations.
+This national extension enforces authentication and authorization of access using the IUA profile with basic access token as described in [IUA](iti-71.html).
+

--- a/input/pagecontent/iti-restful-atna.md
+++ b/input/pagecontent/iti-restful-atna.md
@@ -23,5 +23,5 @@ The Audit Record Repository SHALL support the ATX: FHIR Feed Option.
 The Swiss national extension does not define requirements on the grouping of actors in this profile, which extend or restrict the grouping required from the ATNA profile.
 
 ### Security Consideration
-This national extension enforces authentication and authorization of access using the IUA profile with basic access token as described in [IUA](iti-71.html).
-
+This national extension enforces authentication and authorization of access to the Patient Identifier Cross-reference
+Manager using the IUA profile as described in [IUA](iti-71.html).

--- a/input/pagecontent/ppq-3.md
+++ b/input/pagecontent/ppq-3.md
@@ -107,6 +107,10 @@ The transaction SHALL use client authentication and authorization using one of t
 1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
+The Policy Repository actor shall be grouped with CH:ADR, i.e. the Policy Repository shall use the CH:ADR Authorization 
+Decision Request transaction to authorize the transaction and enforce the authorization decision retrieved from CH:ADR 
+Authorization Decision Response.
+
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
 
 #### Security Audit Considerations

--- a/input/pagecontent/ppq-3.md
+++ b/input/pagecontent/ppq-3.md
@@ -100,13 +100,16 @@ The PPQ-3 response SHALL be created according to the section
 
 ### Security Considerations
 
-TLS SHALL be used. For user authentication and authorization, the IUA profile with extended access token SHALL be used
-as described in the Amendment mHealth of Annex 5, Section 3.2. Consequently, the Mobile Privacy Policy Feed [PPQ-3]
-transaction SHALL be combined with the Incorporate Access Token
-[[ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction of the IUA
-profile.
+The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
+server certificates.
+
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
+
+#### Security Audit Considerations
 
 The **Policy Source** and **Policy Repository** SHALL record the right audit event for the operations:
 

--- a/input/pagecontent/ppq-4.md
+++ b/input/pagecontent/ppq-4.md
@@ -40,13 +40,16 @@ The PPQ-4 response SHALL be created according to the section
 
 ### Security Considerations
 
-TLS SHALL be used. For user authentication and authorization, the IUA profile with extended access token SHALL be used
-as described in the Amendment mHealth of Annex 5, Section 3.2. Consequently, the Mobile Privacy Policy Bundle Feed
-[PPQ-4] transaction SHALL be combined with Incorporate Access Token
-[[ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction of the IUA
-profile.
+The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
+server certificates.
+
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
+
+#### Security Audit Considerations
 
 The **Policy Source** and **Policy Repository** SHALL record the right [PPQ-3] audit event for each operation in the 
 transaction:

--- a/input/pagecontent/ppq-4.md
+++ b/input/pagecontent/ppq-4.md
@@ -47,6 +47,10 @@ The transaction SHALL use client authentication and authorization using one of t
 1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
+The Policy Repository actor shall be grouped with CH:ADR, i.e. the Policy Repository shall use the CH:ADR Authorization
+Decision Request transaction to authorize the transaction and enforce the authorization decision retrieved from CH:ADR
+Authorization Decision Response.
+
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
 
 #### Security Audit Considerations

--- a/input/pagecontent/ppq-5.md
+++ b/input/pagecontent/ppq-5.md
@@ -43,6 +43,10 @@ The transaction SHALL use client authentication and authorization using one of t
 1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
+The Policy Repository actor shall be grouped with CH:ADR, i.e. the Policy Repository shall use the CH:ADR Authorization
+Decision Request transaction to authorize the transaction and enforce the authorization decision retrieved from CH:ADR
+Authorization Decision Response.
+
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
 
 #### Security Audit Considerations

--- a/input/pagecontent/ppq-5.md
+++ b/input/pagecontent/ppq-5.md
@@ -36,13 +36,16 @@ is a Bundle, then it SHALL comply to the
 
 ### Security Considerations
 
-TLS SHALL be used. For user authentication and authorization, the IUA profile with extended access token SHALL be used
-as described in the Amendment mHealth of Annex 5, Section 3.2. Consequently, the Mobile Privacy Policy Retrieve [PPQ-5]
-transaction SHALL be combined with the Incorporate Access Token
-[[ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction of the IUA
-profile.
+The transaction SHALL be secured by Transport Layer Security (TLS) encryption and server authentication with
+server certificates.
+
+The transaction SHALL use client authentication and authorization using one of the following strategies:
+1. Use an extended access token defined in [IUA](iti-71.html) conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
+2. or, use mutual authentication (mTLS) on the transport layer in combination with a XUA token for authorization. The XUA token SHALL be conveyed as defined in the [Incorporate Access Token [ITI-72]](https://profiles.ihe.net/ITI/IUA/index.html#372-incorporate-access-token-iti-72) transaction.
 
 The actors SHALL support the _traceparent_ header handling, as defined in [Appendix: Trace Context](tracecontext.html).
+
+#### Security Audit Considerations
 
 The **Policy Consumer** shall record a
 [CH Audit Event for [PPQ-5] Policy Consumer](StructureDefinition-ChAuditEventPpq5Consumer.html).

--- a/input/pagecontent/ppqm.md
+++ b/input/pagecontent/ppqm.md
@@ -140,7 +140,7 @@ See also:
 - [Description of the official EPR policy stack](https://github.com/ehealthsuisse/ch-epr-adr-ppq/blob/main/docs/Policies.md).
 
 ### Security Consideration
-This national extension enforces authentication and authorization of access using the IUA profile with basic access token as described in [IUA](iti-71.html).
+This national extension enforces authentication and authorization of access using the IUA profile as described in [IUA](iti-71.html).
 
 ### Relation between CH:PPQm and CH:PPQ
 

--- a/input/pagecontent/ppqm.md
+++ b/input/pagecontent/ppqm.md
@@ -139,6 +139,9 @@ See also:
   in the official EPR policy stack.
 - [Description of the official EPR policy stack](https://github.com/ehealthsuisse/ch-epr-adr-ppq/blob/main/docs/Policies.md).
 
+### Security Consideration
+This national extension enforces authentication and authorization of access using the IUA profile with basic access token as described in [IUA](iti-71.html).
+
 ### Relation between CH:PPQm and CH:PPQ
 
 _This section is not normative._


### PR DESCRIPTION
- explicitly calling out the option IUA with SAML/JWT Token option

but we need also to adapt the wording for https://fhir.ch/ig/ch-epr-fhir/iti-iua.html#actor-options: 

This national extension intends to simplify and modernize the technologies used to connect to the Swiss EPR. **The legacy SAML Token option SHALL NOT be used.**