### PR TITLE
rename PPQm to CH:PPQm on home site (OE) #308

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -39,7 +39,7 @@ The extensions, restrictions and translations specified apply to the following I
 
 The following national integration profiles are included in this implementation guide:
 
-* [PPQm](ppqm.html)
+* [CH:PPQm](ppqm.html)
 * [CH:ATC](ch-atc.html)
 
 


### PR DESCRIPTION
https://build.fhir.org/ig/ehealthsuisse/ch-epr-fhir/ppqm.html uses CH:PPQm, the homepage is the only place where only PPQm is used.