### PR TITLE
Fix the ruleset for ChAuditEventIti104ManagerUpdate

### DIFF
--- a/input/fsh/pixm.fsh
+++ b/input/fsh/pixm.fsh
@@ -123,7 +123,7 @@ Parent:      AuditPixmFeedManagerUpdate
 Title:       "CH Audit Event for [ITI-104] Patient Identifier Cross-reference Manager / Update patient"
 Description: "This profile is used to define the CH Audit Event for the [ITI-104] transaction and the actor 'Patient
 Identifier Cross-reference Manager' when updating a patient."
-* insert ChAuditEventExtendedRules
+* insert ChAuditEventBasicRules
 * agent[client] ^short = "The 'Patient Identifier Source' actor (EPR application)"
 * agent[server] ^short = "The 'Patient Identifier Cross-reference Manager' actor (EPR API)"
 * entity[patient].what.identifier 1..1

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -28,6 +28,7 @@
 * ATNA: precise use of STX:HTTPS IUA [#307](https://github.com/ehealthsuisse/ch-epr-fhir/issues/307), [#267](https://github.com/ehealthsuisse/ch-epr-fhir/issues/267), [#265](https://github.com/ehealthsuisse/ch-epr-fhir/issues/265)
 * CH MHD-1: wrong actor Document Recipient, should be Document Responder [#317](https://github.com/ehealthsuisse/ch-epr-fhir/issues/317)
 * mCSD: add Bundle profile and allow only transaction in bundle [#315](https://github.com/ehealthsuisse/ch-epr-fhir/issues/315)
+* PIXm: fix cardinality of the main user agent in ITI-104 Manager Update audit event [#330](https://github.com/ehealthsuisse/ch-epr-fhir/issues/330)
 
 ### DSTU4 Informative Ballot Release 2024-12-18 
 


### PR DESCRIPTION
ChAuditEventIti104ManagerUpdate incorrectly inherited from the extended token ruleset instead of the basic token one.